### PR TITLE
Make basic website available on custom domain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Terraform.
+**/.terraform/*
+*.tfstate
+*.tfstate.*
+crash.log
+crash.*.log
+*.tfvars
+*.tfvars.json
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+.terraformrc
+terraform.rc
+/infrastructure/builds/*

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
+# Waldo's Personal Website
 
+This is pretty much a work in progress.

--- a/infrastructure/.terraform.lock.hcl
+++ b/infrastructure/.terraform.lock.hcl
@@ -1,0 +1,59 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.2.0"
+  hashes = [
+    "h1:62mVchC1L6vOo5QS9uUf52uu0emsMM+LsPQJ1BEaTms=",
+    "zh:06bd875932288f235c16e2237142b493c2c2b6aba0e82e8c85068332a8d2a29e",
+    "zh:0c681b481372afcaefddacc7ccdf1d3bb3a0c0d4678a526bc8b02d0c331479bc",
+    "zh:100fc5b3fc01ea463533d7bbfb01cb7113947a969a4ec12e27f5b2be49884d6c",
+    "zh:55c0d7ddddbd0a46d57c51fcfa9b91f14eed081a45101dbfc7fd9d2278aa1403",
+    "zh:73a5dd68379119167934c48afa1101b09abad2deb436cd5c446733e705869d6b",
+    "zh:841fc4ac6dc3479981330974d44ad2341deada8a5ff9e3b1b4510702dfbdbed9",
+    "zh:91be62c9b41edb137f7f835491183628d484e9d6efa82fcb75cfa538c92791c5",
+    "zh:acd5f442bd88d67eb948b18dc2ed421c6c3faee62d3a12200e442bfff0aa7d8b",
+    "zh:ad5720da5524641ad718a565694821be5f61f68f1c3c5d2cfa24426b8e774bef",
+    "zh:e63f12ea938520b3f83634fc29da28d92eed5cfbc5cc8ca08281a6a9c36cca65",
+    "zh:f6542918faa115df46474a36aabb4c3899650bea036b5f8a5e296be6f8f25767",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.10.0"
+  constraints = "4.10.0"
+  hashes = [
+    "h1:pjPLizna1qa/CZh7HvLuQ73YmqaunLXatyOqzF2ePEI=",
+    "zh:0a2a7eabfeb7dbb17b7f82aff3fa2ba51e836c15e5be4f5468ea44bd1299b48d",
+    "zh:23409c7205d13d2d68b5528e1c49e0a0455d99bbfec61eb0201142beffaa81f7",
+    "zh:3adad2245d97816f3919778b52c58fb2de130938a3e9081358bfbb72ec478d9a",
+    "zh:5bf100aba6332f24b1ffeae7536d5d489bb907bf774a06b95f2183089eaf1a1a",
+    "zh:63c3a24c0c229a1d3390e6ea2454ba4d8ace9b94e086bee1dbdcf665ae969e15",
+    "zh:6b76f5ffd920f0a750da3a4ff1d00eab18d9cd3731b009aae3df4135613bad4d",
+    "zh:8cd6b1e6b51e8e9bbe2944bb169f113d20d1d72d07ccd1b7b83f40b3c958233e",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:c5c31f58fb5bd6aebc6c662a4693640ec763cb3399cce0b592101cf24ece1625",
+    "zh:cc485410be43d6ad95d81b9e54cc4d2117aadf9bf5941165a9df26565d9cce42",
+    "zh:cebb89c74b6a3dc6780824b1d1e2a8d16a51e75679e14ad0b830d9f7da1a3a67",
+    "zh:e7dc427189cb491e1f96e295101964415cbf8630395ee51e396d2a811f365237",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version = "3.1.1"
+  hashes = [
+    "h1:YvH6gTaQzGdNv+SKTZujU1O0bO+Pw6vJHOPhqgN8XNs=",
+    "zh:063466f41f1d9fd0dd93722840c1314f046d8760b1812fa67c34de0afcba5597",
+    "zh:08c058e367de6debdad35fc24d97131c7cf75103baec8279aba3506a08b53faf",
+    "zh:73ce6dff935150d6ddc6ac4a10071e02647d10175c173cfe5dca81f3d13d8afe",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:8fdd792a626413502e68c195f2097352bdc6a0df694f7df350ed784741eb587e",
+    "zh:976bbaf268cb497400fd5b3c774d218f3933271864345f18deebe4dcbfcd6afa",
+    "zh:b21b78ca581f98f4cdb7a366b03ae9db23a73dfa7df12c533d7c19b68e9e72e5",
+    "zh:b7fc0c1615dbdb1d6fd4abb9c7dc7da286631f7ca2299fb9cd4664258ccfbff4",
+    "zh:d1efc942b2c44345e0c29bc976594cb7278c38cfb8897b344669eafbc3cddf46",
+    "zh:e356c245b3cd9d4789bab010893566acace682d7db877e52d40fc4ca34a50924",
+    "zh:ea98802ba92fcfa8cf12cbce2e9e7ebe999afbf8ed47fa45fc847a098d89468b",
+    "zh:eff8872458806499889f6927b5d954560f3d74bf20b6043409edf94d26cd906f",
+  ]
+}

--- a/infrastructure/cloud.tf
+++ b/infrastructure/cloud.tf
@@ -1,0 +1,9 @@
+terraform {
+  cloud {
+    organization = "waldo-io"
+
+    workspaces {
+      name = "waldoibarra-com"
+    }
+  }
+}

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -1,0 +1,16 @@
+module "s3-cloudfront-static-website_example" {
+  source         = "InterweaveCloud/s3-cloudfront-static-website/aws"
+  version        = "0.0.1"
+  resource_uid   = var.domain_name
+  domain_name    = var.domain_name
+  hosted_zone_id = var.hosted_zone_id
+  profile        = var.profile
+  sync_directories = [{
+    local_source_directory = abspath("${path.root}/${var.relative_local_source_directory}")
+    s3_target_directory    = ""
+  }]
+  providers = {
+    aws.useast1 = aws.useast1
+  }
+  Application = var.Application
+}

--- a/infrastructure/provider.tf
+++ b/infrastructure/provider.tf
@@ -1,0 +1,10 @@
+provider "aws" {
+  region  = "us-west-2"
+  profile = ""
+}
+
+provider "aws" {
+  alias   = "useast1"
+  region  = "us-east-1"
+  profile = ""
+}

--- a/infrastructure/vars.tf
+++ b/infrastructure/vars.tf
@@ -1,0 +1,25 @@
+variable "domain_name" {
+  type        = string
+  description = "The domain name for the website."
+}
+
+variable "hosted_zone_id" {
+  type        = string
+  description = "The Hosted Zone ID. This is automatically generated and can be referenced by zone records."
+}
+
+variable "profile" {
+  type        = string
+  description = "Credentials profile to use for aws s3 sync command."
+}
+
+variable "relative_local_source_directory" {
+  type        = string
+  description = "Relative path to S3 source directory."
+}
+
+variable "Application" {
+  type        = string
+  description = "Environment to tag all resources created by this module."
+  default     = "S3 Static Website"
+}

--- a/infrastructure/versions.tf
+++ b/infrastructure/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "4.10.0"
+    }
+  }
+}


### PR DESCRIPTION
Website was made publicly accesible through [waldoibarra.com](https://waldoibarra.com/) using [InterweaveCloud/terraform-aws-s3-cloudfront-static-website](https://github.com/InterweaveCloud/terraform-aws-s3-cloudfront-static-website) Terraform module.

It was done so by logging in into Terraform Cloud and running an apply:
``` sh
terraform apply
```

Closes #1.